### PR TITLE
Update usb9097.py

### DIFF
--- a/tpow/usb9097.py
+++ b/tpow/usb9097.py
@@ -68,7 +68,8 @@ class USB9097:
     def dat_read(self, n):
         self.set_mode(USB9097._MODE_DAT)
         self.uart.write([0xFF]*n)
-        return self.uart.read(n)
+        data = self.uart.read(n)
+        return [bytes([a]) for a in data]
         
 def search_roms(bus):
     """basic rom search algorithm.

--- a/tpow/usb9097.py
+++ b/tpow/usb9097.py
@@ -66,7 +66,9 @@ class USB9097:
         return [_w(a) for a in buf]
         
     def dat_read(self, n):
-        return self.dat_write([0xFF]*n)
+        self.set_mode(USB9097._MODE_DAT)
+        self.uart.write([0xFF]*n)
+        return self.uart.read(n)
         
 def search_roms(bus):
     """basic rom search algorithm.

--- a/tpow/usb9097.py
+++ b/tpow/usb9097.py
@@ -59,6 +59,8 @@ class USB9097:
     def dat_write(self, buf):
         def _w(v):
             self.uart.write([v])
+            if v == 0xE3:
+                self.uart.write([v])
             return self.uart.read(1)
         self.set_mode(USB9097._MODE_DAT)
         return [_w(a) for a in buf]


### PR DESCRIPTION
I found out: sending 0xe3 master runs into check mode. Send a additional 0xe3 to return to data mode. Compare it to state diagram of ds2480b...

<img width="700" alt="image" src="https://github.com/user-attachments/assets/1591e99e-7b60-40c3-8eb7-838ac5d1815e">


The golden reference 'maxim one wire viewer' did it like sending 0xe3 twice.